### PR TITLE
Create memcached_monitor.php

### DIFF
--- a/memcached/memcached_monitor.php
+++ b/memcached/memcached_monitor.php
@@ -1,0 +1,61 @@
+<?php
+//php版本memcached监控
+$falArr = $data = array();
+$conTimeout = 1;
+//采集数据
+if (extension_loaded('memcached')) {
+    $config = array(
+        'servers' => array(//服务器组
+            array('127.0.0.1', 11211),
+        ),
+        'policy' => array(//缓存策略
+            'compressed' => false, //是否压缩,开启后，默认大于100b时压缩
+            'life_time' => 3600, //缓存时间 秒
+            'pool' => 'mc', //连接池，同一连接池建立长连接
+        )
+    );
+    $memcached = new \Memcached($config['policy']['pool']);
+    $memcached->setOption(\Memcached::OPT_COMPRESSION, $config['policy']['compressed']);
+    $memcached->setOption(\Memcached::OPT_CONNECT_TIMEOUT, $conTimeout);
+    if ($memcached->addServers($config['servers'])) {
+        $data = $memcached->getStats();
+    }
+}
+//要监控的key列表
+$monitKeys = array(
+    'uptime' => 'GAUGE',
+    'threads' => 'GAUGE',
+    'pointer_size' => 'GAUGE',
+    'rusage_user_seconds' => 'GAUGE',
+    'rusage_user_microseconds' => 'GAUGE',
+    'rusage_system_seconds' => 'GAUGE',
+    'rusage_system_microseconds' => 'GAUGE',
+    'curr_items' => 'GAUGE',
+    'total_items' => 'GAUGE',
+    'limit_maxbytes' => 'GAUGE',
+    'curr_connections' => 'GAUGE',
+    'total_connections' => 'GAUGE',
+    'connection_structures' => 'GAUGE',
+    'bytes' => 'GAUGE',
+    'cmd_get' => 'GAUGE',
+    'cmd_set' => 'GAUGE',
+    'get_hits' => 'GAUGE',
+    'get_misses' => 'GAUGE',
+    'evictions' => 'GAUGE',
+    'bytes_read' => 'GAUGE',
+    'bytes_written' => 'GAUGE',
+);
+//关联监控指标数值
+foreach ($monitKeys as $k => $v) {
+    $falArr[] = array(
+        "endpoint" => gethostname(),
+        "metric" => "memcached_" . $k,
+        "timestamp" => time(),
+        "step" => 60,
+        "value" => (isset($data[$k]) ? $data[$k] : 0),
+        "counterType" => $v,
+        "tags" => "project=atido,group=server,name=memcached,method=monitor",
+    );
+}
+//stdOut
+echo json_encode($falArr);


### PR DESCRIPTION
1：原生支持php memcached扩展
2:   这些统计函数不用自己计算，getStats里面都有了
3:  可以设置自定义连接超时时间，这点非常重要（memcached太重要）
4:  php代码简单灵活，可把该脚本即成在agent_plugin里面
